### PR TITLE
Remove Unnecessary Trailing Semicolon

### DIFF
--- a/h5bp/directive-only/ssl.conf
+++ b/h5bp/directive-only/ssl.conf
@@ -32,12 +32,12 @@ keepalive_timeout 300s; # up from 75 secs default
 
 # HSTS (HTTP Strict Transport Security)
 # This header tells browsers to cache the certificate for a year and to connect exclusively via HTTPS.
-#add_header Strict-Transport-Security "max-age=31536000;" always;
+#add_header Strict-Transport-Security "max-age=31536000" always;
 # This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
-#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;" always;
+#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 # This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
 # Recommend is also to use preload service
-#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload;" always;
+#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
 # This default SSL certificate will be served whenever the client lacks support for SNI (Server Name Indication).
 # Make it a symlink to the most important certificate you have, so that users of IE 8 and below on WinXP can see your main site without SSL errors.


### PR DESCRIPTION
No need to add a semicolon for the last directive. In addition, having that unnecessary semicolon causes the HSTS tool (https://hstspreload.org/) for getting on the preload list to fail with an error about the semicolon.